### PR TITLE
Add and Configure grunt-contrib-compass

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -30,9 +30,16 @@ module.exports = (grunt) ->
         src: ['js/vex.js', 'js/vex.dialog.js']
         options:
           banner: "/*! vex.js, vex.dialog.js <%= pkg.version %> */\n"
+    
+    compass:
+      dist:
+        options:
+          sassDir: 'sass'
+          cssDir: 'css'
 
   grunt.loadNpmTasks 'grunt-contrib-watch'
   grunt.loadNpmTasks 'grunt-contrib-uglify'
   grunt.loadNpmTasks 'grunt-contrib-coffee'
+  grunt.loadNpmTasks 'grunt-contrib-compass'
 
   grunt.registerTask 'default', ['coffee', 'uglify']

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-cli": "~0.1.9",
     "grunt": "~0.4.1",
-    "grunt-contrib-watch": "~0.5.3"
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-compass": "~0.5.0"
   }
 }


### PR DESCRIPTION
Adds and setups up grunt task for sass.

Uses [grunt-contrib-compass](https://github.com/gruntjs/grunt-contrib-compass)
