### PR TITLE
Fix removal of `".vex-open"` body class when `animationEndSupport` is false

### DIFF
--- a/coffee/vex.coffee
+++ b/coffee/vex.coffee
@@ -147,7 +147,7 @@ vexFactory = ($) ->
             close = ->
                 $vexContent.trigger 'vexClose', options
                 $vex.remove()
-                $('body').trigger 'vexAfterClose', options # Triggerd on the body since $vexContent was removed
+                $('body').trigger 'vexAfterClose', options # Triggered on the body since $vexContent was removed
                 options.afterClose $vexContent, options if options.afterClose
 
             if animationEndSupport


### PR DESCRIPTION
When `animationEndSupport` is false, `vex.getAllVexes().length` was `1` in the check to remove the `vex-open` body class name. By introducing a `vexAfterClose` event fired on the body, we guarantee (for both `animationEndSupport` and not) that our check for any remaining vexes on the page will come _after_ the `$vex` element removal has actually happened. (Fixes #46)
