### PR TITLE
Fixing coffeescript syntax error.

### DIFF
--- a/coffee/vex.dialog.coffee
+++ b/coffee/vex.dialog.coffee
@@ -126,10 +126,12 @@ vexDialogFactory = ($, vex) ->
         $buttons = $('<div class="vex-dialog-buttons" />')
 
         $.each buttons, (index, button) ->
-            $buttons.append $("""<input type="#{button.type}" />""")
+            $button = $("""<input type="#{button.type}" />""")
                 .val(button.text)
                 .addClass(button.className + ' vex-dialog-button ' + (if index is 0 then 'vex-first ' else '') + (if index is buttons.length - 1 then 'vex-last ' else ''))
                 .bind('click.vex', (e) -> button.click($(@).parents(".#{vex.baseClassNames.content}"), e) if button.click)
+        
+            $button.appendTo $buttons
 
         return $buttons
 


### PR DESCRIPTION
Not sure when this was introduced, but this is a syntax error in at least the latest version of coffeescript. The result is:

```
$buttons.append($("<input type=\"" + button.type + "\" />"))
    .val(button.text);
```

when the desired result is:

```
$buttons.append($("<input type=\"" + button.type + "\" />")
    .val(button.text)
);
```
