### PR TITLE
Fix `main` in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "vex",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "homepage": "http://github.hubspot.com/vex/docs/welcome",
   "authors": [
     "Adam Schwartz <aschwartz@hubspot.com>"

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "vex",
   "repo": "HubSpot/vex",
   "description": "Beautiful, functional, dialogs in Javascript",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "homepage": "http://github.hubspot.com/vex",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vex",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "Beautiful, functional, dialogs in Javascript",
   "author": "Adam Schwartz <aschwartz@hubspot.com>",
   "license": "MIT",


### PR DESCRIPTION
The `main` field should point to the primary file used by the library

@timmfin 
