### PR TITLE
Remove unneded files form bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,12 @@
   "license": "MIT",
   "ignore": [
     "node_modules",
-    "bower_components"
+    "bower_components",
+    "docs",
+    ".gitignore",
+    ".hsdoc",
+    "Gruntfile.coffee",
+    "component.json",
+    "package.json"
   ]
 }


### PR DESCRIPTION
Some extra files should be removed from bower package. The are useless within packaged client side library.

I'm not sure about `sass` and `coffee` directories, so I left them in the package.