### PR TITLE
Proposed update to default className

### DIFF
--- a/coffee/vex.coffee
+++ b/coffee/vex.coffee
@@ -35,7 +35,7 @@ vexFactory = ($) ->
             escapeButtonCloses: true
             overlayClosesOnClick: true
             appendLocation: 'body'
-            className: ''
+            className: 'vex-theme-os'
             css: {}
             overlayClassName: ''
             overlayCSS: {}

--- a/coffee/vex.coffee
+++ b/coffee/vex.coffee
@@ -35,7 +35,7 @@ vexFactory = ($) ->
             escapeButtonCloses: true
             overlayClosesOnClick: true
             appendLocation: 'body'
-            className: 'vex-theme-os'
+            className: 'vex-theme-default'
             css: {}
             overlayClassName: ''
             overlayCSS: {}


### PR DESCRIPTION
I propose that there is a default theme selected upon start. This makes it just a little bit easier when starting using vex for a few people. In my case I use brunch to bake vex into all of my stuff. I would love to not have a setup phase for vex if I am content with the plain vex-theme-os.
