### PR TITLE
Fix amd support and webpack

### DIFF
--- a/js/vex.dialog.js
+++ b/js/vex.dialog.js
@@ -143,7 +143,7 @@
   };
 
   if (typeof define === 'function' && define.amd) {
-    define(['jquery', 'vex'], vexDialogFactory);
+    define(['jquery', 'vex-js'], vexDialogFactory);
   } else if (typeof exports === 'object') {
     module.exports = vexDialogFactory(require('jquery'), require('./vex.js'));
   } else {


### PR DESCRIPTION
This changes the module dependency to the correct package name in npm.
It fixed webpack usage. Related issues: #141, #60
