### PR TITLE
Fix popstate event listener

### DIFF
--- a/src/vex.js
+++ b/src/vex.js
@@ -294,7 +294,7 @@ window.addEventListener('keyup', function vexKeyupListener (e) {
   }
 })
 // Close all vexes on history pop state (useful in single page apps)
-window.addEventListener('popstate', vex.closeAll)
+window.addEventListener('popstate', vex.closeAll.bind(vex))
 
 vex.defaultOptions = {
   content: '',


### PR DESCRIPTION
`this` is bound to `window` when `vex.closeAll()` runs. This isn't supposed to happen but I noticed it because the function is supposed to call `vex.close()` but it  actually calls `window.close()` which leads to warnings in the console.