### PR TITLE
 Make sure ./dist gets built as part of releasing. Fixes #201

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "standard": "7.1.2"
   },
   "scripts": {
+    "prepublish" : "grunt",
     "test": "standard",
     "build": "grunt"
   },


### PR DESCRIPTION
Attempts to Fix #201 by automating running "grunt" whenever "npm publish" is run.

Needs tested.