### PR TITLE
Documentation improvements

### DIFF
--- a/docs/api/2-Themes.md
+++ b/docs/api/2-Themes.md
@@ -1,6 +1,6 @@
 ## Themes
 
-To use a builtin theme, you must include the theme style sheet, and set vex `className` to match match:
+To use a builtin theme, you must include the theme style sheet, and set vex `className` to match:
 
 ```html
 <link rel="stylesheet" href="vex-theme-default.css" />

--- a/docs/api/3-Advanced.md
+++ b/docs/api/3-Advanced.md
@@ -116,7 +116,7 @@ defaultOptions: {
     overlayClassName: '',
     contentClassName: '',
     closeClassName: '',
-    closeAllOnPopState:true
+    closeAllOnPopState: true
 }
 ```
 
@@ -133,8 +133,9 @@ In addition to these string options, there are also three callback functions you
 
 Each callback is called with the context of the vex instance. That is, the keyword `this` inside of these callback functions references the vex instance.
 
-Lastly, when using single-page applications, the default behavior is for vex to close all open dialogs on state transitions. 
-Setting `closeAllOnPopState` to `false` will allow these dialogs to persist across state changes. 
+Lastly, when using single-page applications, the default behavior is for vex to close all open dialogs when a history state change causes a `popstate` event. 
+Setting `vex.defaultOptions.closeAllOnPopState` to `false` will allow these dialogs to persist across state changes.
+This option has no effect when passed to `vex.open()`.
 
 ### Note about Includes
 

--- a/docs/api/3-Advanced.md
+++ b/docs/api/3-Advanced.md
@@ -100,9 +100,9 @@ A boolean indicating whether the instance is open/visible.
 
 #### Options
 
-When calling `vex.open()` you can pass a number of options to handle styling and certain behaviors.
+When calling `vex.open()` you can pass a number of options to handle styling and certain behaviors. You can also set the properties of `vex.defaultOptions` to affect all future calls.
 
-Here are the defaults:
+`vex.defaultOptions` is initially set to this object:
 
 ```javascript
 defaultOptions: {

--- a/docs/api/3-Advanced.md
+++ b/docs/api/3-Advanced.md
@@ -102,7 +102,7 @@ A boolean indicating whether the instance is open/visible.
 
 When calling `vex.open()` you can pass a number of options to handle styling and certain behaviors. You can also set the properties of `vex.defaultOptions` to affect all future calls.
 
-`vex.defaultOptions` is initially set to this object:
+`vex.defaultOptions` is initially this object:
 
 ```javascript
 defaultOptions: {


### PR DESCRIPTION
With these edits to the doc pages:
* `vex.defaultOptions` is introduced to developers who, for whatever reason, skipped the Basic page and went right to Advanced
* The `closeAllOnPopState` option is clarified, including the formerly-unmentioned wrinkle that it works only as a default option
* A duplicate word error on the Themes page is fixed

Someone at HubSpot, perhaps @timmfin, will need to update vex's HubSpot site after this PR goes through.