### PR TITLE
docs: Fix simple typo, ingore -> ignore

### DIFF
--- a/dist/js/vex.combined.js
+++ b/dist/js/vex.combined.js
@@ -446,7 +446,7 @@ function serialize(form, options) {
     for (var i=0 ; i<elements.length ; ++i) {
         var element = elements[i];
 
-        // ingore disabled fields
+        // ignore disabled fields
         if ((!options.disabled && element.disabled) || !element.name) {
             continue;
         }
@@ -824,7 +824,7 @@ function serialize(form, options) {
     for (var i=0 ; i<elements.length ; ++i) {
         var element = elements[i];
 
-        // ingore disabled fields
+        // ignore disabled fields
         if ((!options.disabled && element.disabled) || !element.name) {
             continue;
         }


### PR DESCRIPTION
There is a small typo in dist/js/vex.combined.js.

Should read `ignore` rather than `ingore`.

